### PR TITLE
Feature/cron expression extension

### DIFF
--- a/net.solarnetwork.node.setup.web/web/WEB-INF/jsp/a/settings/setting-control.jsp
+++ b/net.solarnetwork.node.setup.web/web/WEB-INF/jsp/a/settings/setting-control.jsp
@@ -140,6 +140,7 @@
 						<input type="${setting.secureTextEntry == true ? 'password' : 'text' }" name="${settingId}" id="${settingId}"
 							class="span5" maxLength="255" value="${settingValue}"/>
 						<select name="${settingId}_select" id="${settingId}_select" >
+							<option disabled selected> -- Common Schedules -- </option>
 							<option value="* * * * * ?">Every Minute</option>
 							<option value="0 0 * * * ?">Every Day (Midnight)</option>
 							<option value="0 0 1 * * ?">Every month (on the 1st)</option>

--- a/net.solarnetwork.node.setup.web/web/WEB-INF/jsp/a/settings/setting-control.jsp
+++ b/net.solarnetwork.node.setup.web/web/WEB-INF/jsp/a/settings/setting-control.jsp
@@ -137,14 +137,14 @@
 						</script>
 					</c:when>
 					<c:when test="${setup:instanceOf(setting, 'net.solarnetwork.node.settings.CronExpressionSettingSpecifier')}">
-						<input type="${setting.secureTextEntry == true ? 'password' : 'text' }" name="${settingId}" id="${settingId}"
-							class="span5" maxLength="255" value="${settingValue}"/>
 						<select name="${settingId}_select" id="${settingId}_select" >
-							<option disabled selected> -- Common Schedules -- </option>
+							<option value="" selected>Custom Schedule</option>
 							<option value="* * * * * ?">Every Minute</option>
 							<option value="0 0 * * * ?">Every Day (Midnight)</option>
 							<option value="0 0 1 * * ?">Every month (on the 1st)</option>
 						</select>
+						<input type="${setting.secureTextEntry == true ? 'password' : 'text' }" name="${settingId}" id="${settingId}"
+							class="span2" maxLength="255" value="${settingValue}"/>
 						<script>
 						$(function() {
 							SolarNode.Settings.addCronField({

--- a/net.solarnetwork.node.setup.web/web/WEB-INF/jsp/a/settings/setting-control.jsp
+++ b/net.solarnetwork.node.setup.web/web/WEB-INF/jsp/a/settings/setting-control.jsp
@@ -136,6 +136,26 @@
 						});
 						</script>
 					</c:when>
+					<c:when test="${setup:instanceOf(setting, 'net.solarnetwork.node.settings.CronExpressionSettingSpecifier')}">
+						<input type="${setting.secureTextEntry == true ? 'password' : 'text' }" name="${settingId}" id="${settingId}"
+							class="span5" maxLength="255" value="${settingValue}"/>
+						<select name="${settingId}_select" id="${settingId}_select" >
+							<option value="* * * * * ?">Every Minute</option>
+							<option value="0 0 * * * ?">Every Day (Midnight)</option>
+							<option value="0 0 1 * * ?">Every month (on the 1st)</option>
+						</select>
+						<script>
+						$(function() {
+							SolarNode.Settings.addCronField({
+								key: '${settingId}',
+								xint: '${setting["transient"]}',
+								provider: '${provider.settingUID}',
+								setting: '${setup:js(setting.key)}',
+								instance: '${instanceId}'
+							});
+						});
+						</script>
+					</c:when>
 					<c:when test="${setup:instanceOf(setting, 'net.solarnetwork.node.settings.TextFieldSettingSpecifier')}">
 						<input type="${setting.secureTextEntry == true ? 'password' : 'text' }" name="${settingId}" id="${settingId}" 
 							class="span5" maxLength="255"

--- a/net.solarnetwork.node.setup.web/web/js/settings.js
+++ b/net.solarnetwork.node.setup.web/web/js/settings.js
@@ -162,11 +162,13 @@ SolarNode.Settings.addTextField = function(params) {
 SolarNode.Settings.addCronField = function(params) {
 	var field = $('#'+params.key);
 	var fieldSelect = $('#'+params.key+"_select");
+	var currentValue = field.val();
+	// Check when page initially loads
+	SolarNode.Settings.checkCronMatch(currentValue, params.key, fieldSelect);
 	field.change(function() {
 			var value = field.val();
 			SolarNode.Settings.updateSetting(params, value);
-			// Clears select field if custom value given, sets back to disabled option
-			fieldSelect.find('option:disabled:first').prop('selected', true);
+			SolarNode.Settings.checkCronMatch(value, params.key, fieldSelect);
 			
 		});
 	fieldSelect.change(function() {
@@ -175,6 +177,18 @@ SolarNode.Settings.addCronField = function(params) {
 			SolarNode.Settings.updateSetting(params, value);
 		});
 };
+
+/**
+ * Helper method to check if the text input's cron expression matches any of the select options.
+ * If it does, it selects the option. If it does not, sets back to default option.
+ */
+SolarNode.Settings.checkCronMatch = function(value, key, fieldSelect) {
+	if ($('#'+key+'_select option[value="'+value+'"]').length > 0) {
+		fieldSelect.val(value);
+	} else {
+		fieldSelect.find('option:disabled:first').prop('selected', true);
+	}
+}
 
 /**
  * Setup a new location finder field.

--- a/net.solarnetwork.node.setup.web/web/js/settings.js
+++ b/net.solarnetwork.node.setup.web/web/js/settings.js
@@ -152,6 +152,29 @@ SolarNode.Settings.addTextField = function(params) {
 };
 
 /**
+ * Setup cron fields (text field and select box).
+ *
+ * @param params.provider {String} the provider key
+ * @param params.setting {String} the setting key
+ * @param params.key {String} the DOM element ID for the text field
+ * @param params.value {String} the initial value
+ */
+SolarNode.Settings.addCronField = function(params) {
+	var field = $('#'+params.key);
+	field.change(function() {
+			var value = field.val();
+			console.log(value);
+			SolarNode.Settings.updateSetting(params, value);
+		});
+	var fieldSelect = $('#'+params.key+"_select");
+	fieldSelect.change(function() {
+			var value = fieldSelect.val();
+			field.val(value);
+			SolarNode.Settings.updateSetting(params, value);
+		});
+};
+
+/**
  * Setup a new location finder field.
  * 
  * @param params.provider {String} the provider key

--- a/net.solarnetwork.node.setup.web/web/js/settings.js
+++ b/net.solarnetwork.node.setup.web/web/js/settings.js
@@ -175,6 +175,7 @@ SolarNode.Settings.addCronField = function(params) {
 			var value = fieldSelect.val();
 			field.val(value);
 			SolarNode.Settings.updateSetting(params, value);
+			SolarNode.Settings.checkCronMatch(value, params.key, fieldSelect);
 		});
 };
 
@@ -183,9 +184,13 @@ SolarNode.Settings.addCronField = function(params) {
  * If it does, it selects the option. If it does not, sets back to default option.
  */
 SolarNode.Settings.checkCronMatch = function(value, key, fieldSelect) {
-	if ($('#'+key+'_select option[value="'+value+'"]').length > 0) {
+	if (value != "" & $('#'+key+'_select option[value="'+value+'"]').length > 0) {
 		fieldSelect.val(value);
+		$('#'+key+'_select').attr('class', 'span5');
+		$('#'+key).hide();
 	} else {
+		$('#'+key).show();
+		$('#'+key+'_select').attr('class', 'span3');
 		fieldSelect.find('option:disabled:first').prop('selected', true);
 	}
 }

--- a/net.solarnetwork.node.setup.web/web/js/settings.js
+++ b/net.solarnetwork.node.setup.web/web/js/settings.js
@@ -161,12 +161,14 @@ SolarNode.Settings.addTextField = function(params) {
  */
 SolarNode.Settings.addCronField = function(params) {
 	var field = $('#'+params.key);
+	var fieldSelect = $('#'+params.key+"_select");
 	field.change(function() {
 			var value = field.val();
-			console.log(value);
 			SolarNode.Settings.updateSetting(params, value);
+			// Clears select field if custom value given, sets back to disabled option
+			fieldSelect.find('option:disabled:first').prop('selected', true);
+			
 		});
-	var fieldSelect = $('#'+params.key+"_select");
 	fieldSelect.change(function() {
 			var value = fieldSelect.val();
 			field.val(value);


### PR DESCRIPTION
Related to [Issue #1](https://github.com/kblincoe/solarnetwork-node_SE701/issues/1)

Added feature that allows users to select common cron expressions, such as "run every minute", while still allowing advanced users to input their own custom expressions/values.
____

**Changes:**
- Added a select input field with several common/basic cron expressions preset: 'Every Minute', 'Every Day', and 'Every Month'. Any extra preset values can easily be added by adding options to the ```setting-control.jsp``` file.

- When an option is selected, the value of the text input is also updated to indicate it has been selected. 

- Added a default/initial disabled value to the select box. If an option is selected, but then a custom expression is given in the text input, the select box resets back to the default value.

<img width="901" alt="screen shot 2018-03-28 at 2 44 33 pm" src="https://user-images.githubusercontent.com/21206638/38003975-920667ca-3296-11e8-8fcc-28cc500434a7.png">
