### PR TITLE
Feature/Reset Settings components to their default values

### DIFF
--- a/net.solarnetwork.node.settings.ca/src/net/solarnetwork/node/settings/ca/CASettingsService.java
+++ b/net.solarnetwork.node.settings.ca/src/net/solarnetwork/node/settings/ca/CASettingsService.java
@@ -537,6 +537,11 @@ public class CASettingsService implements SettingsService, BackupResourceProvide
 			}
 		}
 	}
+	
+	@Override
+	public void resetProviderFactoryInstance(String factoryUID, String instanceUID) {
+		throw new UnsupportedOperationException();
+	}
 
 	private static final String[] CSV_HEADERS = new String[] { "key", "type", "value", "flags",
 			"modified" };

--- a/net.solarnetwork.node.setup.web/src/net/solarnetwork/node/setup/web/SettingsController.java
+++ b/net.solarnetwork.node.setup.web/src/net/solarnetwork/node/setup/web/SettingsController.java
@@ -151,6 +151,18 @@ public class SettingsController {
 		}
 		return response(null);
 	}
+	
+	@RequestMapping(value = "/manage/reset", method = RequestMethod.POST)
+	@ResponseBody
+	public Response<Object> resetConfiguration(
+			@RequestParam(value = "uid", required = true) String factoryUID,
+			@RequestParam(value = "instance", required = true) String instanceUID) {
+		final SettingsService service = settingsServiceTracker.service();
+		if ( service != null ) {
+			service.resetProviderFactoryInstance(factoryUID, instanceUID);
+		}
+		return response(null);
+	}
 
 	@RequestMapping(value = "/save", method = RequestMethod.POST)
 	@ResponseBody

--- a/net.solarnetwork.node.setup.web/web/WEB-INF/jsp/a/settings/factory-list.jsp
+++ b/net.solarnetwork.node.setup.web/web/WEB-INF/jsp/a/settings/factory-list.jsp
@@ -77,7 +77,7 @@
 									});
 								});
 								</script>
-								<button type="button" class="btn btn-danger" id="reset${instance.key}">
+								<button type="button" class="btn btn-primary" id="reset${instance.key}">
 									<fmt:message key='settings.factory.reset'>
 										<fmt:param><setup:message key="title" messageSource="${factory.messageSource}" text="${factory.displayName}"/></fmt:param>
 										<fmt:param value="${instance.key}"/>

--- a/net.solarnetwork.node.setup.web/web/WEB-INF/jsp/a/settings/factory-list.jsp
+++ b/net.solarnetwork.node.setup.web/web/WEB-INF/jsp/a/settings/factory-list.jsp
@@ -77,6 +77,22 @@
 									});
 								});
 								</script>
+								<button type="button" class="btn btn-danger" id="reset${instance.key}">
+									<fmt:message key='settings.factory.reset'>
+										<fmt:param><setup:message key="title" messageSource="${factory.messageSource}" text="${factory.displayName}"/></fmt:param>
+										<fmt:param value="${instance.key}"/>
+									</fmt:message>
+								</button>
+								<script>
+								$('#reset${instance.key}').click(function() {
+									SolarNode.Settings.resetFactoryConfiguration({
+										button: this,
+										url: '<setup:url value="/a/settings/manage/reset"/>',
+										factoryUID: '${factory.factoryUID}',
+										instanceUID: '${instance.key}'
+									});
+								});
+								</script>
 							</div>
 						</div>
 					</fieldset>
@@ -116,6 +132,16 @@ $(function() {
 	</p>
 	<button type="button" class="btn btn-danger submit">
 		<fmt:message key="delete.label"/>
+	</button>
+</div>
+<div id="alert-reset" class="alert alert-danger alert-block hidden">
+	<button type="button" class="close" data-dismiss="alert">×</button>
+	<h4><fmt:message key="settings.factory.reset.alert.title"/></h4>
+	<p>
+		<fmt:message key="settings.factory.reset.alert.msg"/>
+	</p>
+	<button type="button" class="btn btn-danger submit">
+		<fmt:message key="reset.label"/>
 	</button>
 </div>
 <form class="modal dynamic hide fade lookup-modal sn-loc-lookup-modal price-lookup-modal" 

--- a/net.solarnetwork.node.setup.web/web/WEB-INF/messages.properties
+++ b/net.solarnetwork.node.setup.web/web/WEB-INF/messages.properties
@@ -249,8 +249,8 @@ settings.factory.delete = Delete {0} {1}
 settings.factory.delete.alert.title = Really delete?
 settings.factory.delete.alert.msg = Are you sure you want to delete this configuration? This action \
 	cannot be undone.
-settings.factory.reset = Reset {0} {1} to default
-settings.factory.reset.alert.title = Really reset back to default?
+settings.factory.reset = Restore {0} {1} to default values
+settings.factory.reset.alert.title = Really restore values back to default?
 settings.factory.reset.alert.msg = Are you sure you want to reset this configuration? This action \
 	cannot be undone.
 

--- a/net.solarnetwork.node.setup.web/web/WEB-INF/messages.properties
+++ b/net.solarnetwork.node.setup.web/web/WEB-INF/messages.properties
@@ -5,6 +5,7 @@ ok.label = OK
 back.label = Back
 cancel.label = Cancel
 delete.label = Delete
+reset.label = Reset
 close.label = Close
 error.unexpected = An unexpected error occurred: {0}
 field.required = The field is required.
@@ -247,6 +248,10 @@ settings.factory.add = Add new {0} configuration
 settings.factory.delete = Delete {0} {1}
 settings.factory.delete.alert.title = Really delete?
 settings.factory.delete.alert.msg = Are you sure you want to delete this configuration? This action \
+	cannot be undone.
+settings.factory.reset = Reset {0} {1} to default
+settings.factory.reset.alert.title = Really reset back to default?
+settings.factory.reset.alert.msg = Are you sure you want to reset this configuration? This action \
 	cannot be undone.
 
 settings.io.title = Settings backup & restore

--- a/net.solarnetwork.node.setup.web/web/js/settings.js
+++ b/net.solarnetwork.node.setup.web/web/js/settings.js
@@ -363,30 +363,8 @@ SolarNode.Settings.addFactoryConfiguration = function(params) {
  * or confirm the deletion by clicking another button.
  */
 SolarNode.Settings.deleteFactoryConfiguration = function(params) {
-	var origButton = $(params.button);
-	origButton.attr('disabled', 'disabled');
-	var alert = $('#alert-delete').clone();
-	
-	var reallyDeleteButton = alert.find('button.submit');
-	reallyDeleteButton.click(function() {
-		$(this).attr('disabled', 'disabled');
-		$.ajax({
-			type : 'POST',
-			url : params.url,
-			data : {uid: params.factoryUID, instance: params.instanceUID},
-			beforeSend: function(xhr) {
-				SolarNode.csrf(xhr);
-	        },
-			success: delayedReload
-		});
-	});
-	alert.bind('close', function(e) {
-		origButton.removeAttr('disabled');
-		origButton.removeClass('hidden');
-		reallyDeleteButton.unbind();
-	});
-	origButton.addClass('hidden');
-	alert.insertAfter(origButton).removeClass('hidden');
+	params['alert'] = '#alert-delete'
+	SolarNode.Settings.showConfirmation(params);
 };
 
 /**
@@ -395,12 +373,21 @@ SolarNode.Settings.deleteFactoryConfiguration = function(params) {
  * or confirm the reset by clicking another button.
  */
 SolarNode.Settings.resetFactoryConfiguration = function(params) {
+	params['alert'] = '#alert-reset'
+	SolarNode.Settings.showConfirmation(params);
+};
+
+/**
+ * Show an alert element asking the user if they if they want to complete
+ * the current action
+ */
+SolarNode.Settings.showConfirmation = function(params) {
 	var origButton = $(params.button);
 	origButton.attr('disabled', 'disabled');
-	var alert = $('#alert-reset').clone();
+	var alert = $(params.alert).clone();
 	
-	var reallyDeleteButton = alert.find('button.submit');
-	reallyDeleteButton.click(function() {
+	var confirmationButton = alert.find('button.submit');
+	confirmationButton.click(function() {
 		$(this).attr('disabled', 'disabled');
 		$.ajax({
 			type : 'POST',
@@ -415,11 +402,12 @@ SolarNode.Settings.resetFactoryConfiguration = function(params) {
 	alert.bind('close', function(e) {
 		origButton.removeAttr('disabled');
 		origButton.removeClass('hidden');
-		reallyDeleteButton.unbind();
+		confirmationButton.unbind();
 	});
 	origButton.addClass('hidden');
 	alert.insertAfter(origButton).removeClass('hidden');
 };
+
 
 function formatTimestamp(date) {
 	if ( !date ) {

--- a/net.solarnetwork.node.setup.web/web/js/settings.js
+++ b/net.solarnetwork.node.setup.web/web/js/settings.js
@@ -389,6 +389,38 @@ SolarNode.Settings.deleteFactoryConfiguration = function(params) {
 	alert.insertAfter(origButton).removeClass('hidden');
 };
 
+/**
+ * Show an alert element asking the user if they really want to reset
+ * the selected factory configuration to default, and allow them to dismiss the alert
+ * or confirm the reset by clicking another button.
+ */
+SolarNode.Settings.resetFactoryConfiguration = function(params) {
+	var origButton = $(params.button);
+	origButton.attr('disabled', 'disabled');
+	var alert = $('#alert-reset').clone();
+	
+	var reallyDeleteButton = alert.find('button.submit');
+	reallyDeleteButton.click(function() {
+		$(this).attr('disabled', 'disabled');
+		$.ajax({
+			type : 'POST',
+			url : params.url,
+			data : {uid: params.factoryUID, instance: params.instanceUID},
+			beforeSend: function(xhr) {
+				SolarNode.csrf(xhr);
+	        },
+			success: delayedReload
+		});
+	});
+	alert.bind('close', function(e) {
+		origButton.removeAttr('disabled');
+		origButton.removeClass('hidden');
+		reallyDeleteButton.unbind();
+	});
+	origButton.addClass('hidden');
+	alert.insertAfter(origButton).removeClass('hidden');
+};
+
 function formatTimestamp(date) {
 	if ( !date ) {
 		return;

--- a/net.solarnetwork.node/src/net/solarnetwork/node/settings/SettingsService.java
+++ b/net.solarnetwork.node/src/net/solarnetwork/node/settings/SettingsService.java
@@ -81,6 +81,16 @@ public interface SettingsService {
 	void deleteProviderFactoryInstance(String factoryUID, String instanceUID);
 
 	/**
+	 * Reset an existing factory instance to its default values.
+	 * 
+	 * @param factoryUID
+	 *        the factory UID to create the new instance for
+	 * @param instanceUID
+	 *        the instance UID to create the new instance for
+	 */
+	void resetProviderFactoryInstance(String factoryUID, String instanceUID);
+	
+	/**
 	 * Get all possible setting providers for a specific factory UID, grouped by
 	 * instance ID.
 	 * 


### PR DESCRIPTION
Closes #2
A restore component button has been added to each Setting Component next to the delete button.
When the user presses the restore button a notification will be shown to the user warning them that this action can not be undone. If the user accepts the page is reloaded with the default values.
Note that this implementation relies on being able to delete persisted settings therefore it is reliant on #12 